### PR TITLE
Set fullPath from string if ICU failed.

### DIFF
--- a/src/main/scala/code/model/RepositoryDoc.scala
+++ b/src/main/scala/code/model/RepositoryDoc.scala
@@ -122,7 +122,7 @@ class RepositoryDoc private() extends MongoRecord[RepositoryDoc] with ObjectIdPk
 
       val list = new ArrayBuffer[SourceElement](50)
       while (walk.next) {
-        val fullPath = (guessString(Some(walk.getRawPath)) getOrElse "").split("/").toList
+        val fullPath = (guessString(Some(walk.getRawPath)) getOrElse walk.getPathString()).split("/").toList
 
         list +=
           (if (walk.getFileMode(level) == FileMode.TREE) 


### PR DESCRIPTION
Добрый день, Денис.

  Мы тут нашли забавный баг. В одном из репозиториев не показывался файл src-plugins/build.sbt. Я покопался -- похоже что проблема в ICU. Этот фикс - чтобы показать хоть что то если ICU не смогло сконвертировать строчку.

Вот тест на этот баг:

object TestEnc {
  val good = Array[Byte]('s',)

  val bad = Array[Byte]('s',)

```
def main(argc: Array[String]) {
  println("S=" + (new com.ibm.icu.text.CharsetDetector).setText(good).getString(good, null))
  println("S=" + (new com.ibm.icu.text.CharsetDetector).setText(bad).getString(bad, null))
}
```

}

Результат работы:
S=src-plugins/build.bak
S=null
