### PR TITLE
Commit record in source view escaped twice.

### DIFF
--- a/src/main/scala/code/snippet/SourceElementOps.scala
+++ b/src/main/scala/code/snippet/SourceElementOps.scala
@@ -72,8 +72,8 @@ class SourceElementOps(se: SourceElement) extends Loggable {
                     case t @ Tree(_, _, _) => <a class="folder_element" href={treeAtCommit.calcHref(t)}>{t.name}/</a>
                     case b @ Blob(_, _, _, _) => <a href={blobAtCommit.calcHref(b)}>{b.name}</a>
                   }} &
-              ".date *" #> c.map(cc => escape(dateFormat(cc.getCommitterIdent.getWhen))) &
-              ".last_commit *" #> c.map(cc => "%s [%s]".format(escape(cc.getShortMessage), cc.getCommitterIdent().getName()))
+              ".date *" #> c.map(cc => dateFormat(cc.getCommitterIdent.getWhen)) &
+              ".last_commit *" #> c.map(cc => "%s [%s]".format(cc.getShortMessage, cc.getCommitterIdent().getName()))
          })).openOr(".source_element" #> NodeSeq.Empty)
          
       }


### PR DESCRIPTION
Денис, добрый день.

  Нашли такую багу - в source view commit record ескейпится дважды (например у нас в комите символы <> выглядели как &lt; &gt;). Как я понимаю происходит это потому что ToCssBindPromoter.#>(str:String) конструирует Text(str) (см. https://github.com/lift/framework/blob/master/core/util/src/main/scala/net/liftweb/util/BindHelpers.scala#L1408), который при распаковке в строчку сам вызывает escape (https://github.com/scala/scala/blob/v2.9.2/src/library/scala/xml/Text.scala#L47).
